### PR TITLE
Fix gorko & fledge's dungeon dependency

### DIFF
--- a/src/data/potentialBannedLocations.json
+++ b/src/data/potentialBannedLocations.json
@@ -1,16 +1,6 @@
 {
-    "Knight Academy": {
-        "Fledge's Crystals": {
-            "requiredDungeon": "Lanayru Mining Facility"
-        }
-    },
     "Sky": {
         "Lumpy Pumpkin - Goddess Chest on the Roof": {
-            "requiredDungeon": "Skyview"
-        }
-    },
-    "Sealed Grounds": {
-        "Gorko's Goddess Wall Reward": {
             "requiredDungeon": "Skyview"
         }
     }


### PR DESCRIPTION
Woo, on a roll. Small one, just making it so Gorko and Fledge are no longer dependent on SV/LMF being required if EUD is on.