### PR TITLE
Remove problematic final else block

### DIFF
--- a/src/Tracker.js
+++ b/src/Tracker.js
@@ -196,8 +196,6 @@ class Tracker extends React.Component {
                 startingItems.push('Triforce');
             } else if (!item.includes('Pouch') | !startingItems.includes('Progressive Pouch')) {
                 startingItems.push(item);
-            } else {
-                startingItems.push(item);
             }
         });
         const logic = new Logic();


### PR DESCRIPTION
With the previous hotfix, superfluous pouches would still be added by the last else block, which is not intended. By having the "else if not pouch or not pouch in inventory" be the last condition, extra pouches will be filtered out by the end and not added. 