### PR TITLE
Undo Obsolete Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,11 +253,13 @@ all misaligned items
 ## Additions
 - Added support for tracking path hints (by YourAverageLink)
   - Right clicking a region has a new submenu for path hints, which will then display an icon of the corresponding boss near the region
+- Added support for the new options (by YourAverageLink)
+  - Any starting items that appear in the supplied settings string will be given to start with.
+  - Any locations excluded in the settings string will not appear on the tracker.
+
 
 ## Changes
-- Until the logic parsing system is updated to match the new graph logic, logic has been frozen to the last old logic version
-- In the meantime, all other options retain support with some temporary solutions (by YourAverageLink)
-  - The front menu has been stripped down as banned types have been removed, but all banned locations specified in the permalink will be removed
+- Until the logic parsing system is updated to match the new graph logic, the tracker will use the old logic files in the meantime (by CovenEsme)
 
 ## Bug Fixes
 - Fixed a few missing items in the Item Hint menu

--- a/src/Tracker.js
+++ b/src/Tracker.js
@@ -165,8 +165,6 @@ class Tracker extends React.Component {
         await this.state.settings.init();
         this.state.settings.updateFromPermalink(permalink);
         const startingItems = [];
-        // temporarily include this to retain old option functionality until logic unfreezes
-        this.state.settings.setOption('Hero Mode', this.state.settings.getOption('Upgraded Skyward Strike'));
         this.state.settings.setOption('open-et', this.state.settings.getOption('Open Earth Temple'));
         startingItems.push('Sailcloth');
         if (this.state.settings.getOption('Starting Tablet Count') === 3) {

--- a/src/logic/Locations.js
+++ b/src/logic/Locations.js
@@ -7,23 +7,7 @@ class Locations {
         this.locations = {};
         this.bannedLocations = settings.getOption('Excluded Locations');
         _.forEach(locationsFile, (data, name) => {
-            let nonprogress = false;
-            // temporary fix for mismatched names
-            let tempName = name.replace('Knight Academy -', 'Upper Skyloft -');
-            tempName = tempName.replace('Beedle -', 'Beedle\'s Shop -');
-            tempName = tempName.replace('Batreaux -', 'Batreaux\'s House -');
-            tempName = tempName.replace('Faron Soth', 'Water Dragon\'s Reward');
-            tempName = tempName.replace('Lanayru Soth', 'Thunder Dragon\'s Reward');
-            tempName = tempName.replace('Harp Minigame', '- Harp Minigame');
-            if (this.bannedLocations.includes(tempName)) {
-                nonprogress = true;
-            }
-            // replaces last dash with double dash (as in new minigame names)
-            let minigameName = [...tempName].reverse().join('');
-            minigameName = [...minigameName.replace('-', '--')].reverse().join('');
-            if (this.bannedLocations.includes(minigameName)) {
-                nonprogress = true;
-            }
+            let nonprogress = this.bannedLocations.includes(name);
             const {
                 area,
                 location,
@@ -39,11 +23,11 @@ class Locations {
             } else {
                 maxBeedle = 1600;
             }
-            if (area === 'Batreaux') {
-                nonprogress = (parseInt(location.replace(/^\D+/g, ''), 10) > settings.getOption('Max Batreaux Reward'));
+            if (area === 'Batreaux\'s House') {
+                nonprogress |= (parseInt(location.replace(/^\D+/g, ''), 10) > settings.getOption('Max Batreaux Reward'));
             }
-            if (area === 'Beedle') {
-                nonprogress = (parseInt(location.replace(/^\D+/g, ''), 10) > maxBeedle);
+            if (area === 'Beedle\'s Shop') {
+                nonprogress |= (parseInt(location.replace(/^\D+/g, ''), 10) > maxBeedle);
             }
             const itemLocation = ItemLocation.emptyLocation();
             itemLocation.name = location;

--- a/src/logic/LogicLoader.js
+++ b/src/logic/LogicLoader.js
@@ -22,11 +22,6 @@ class LogicLoader {
     static logicFileUrl(file) {
         return `https://raw.githubusercontent.com/ssrando/ssrando/master/${file}`;
     }
-
-    static async loadNewLogicChecks() {
-        const data = await this.loadFileFromUrl('https://raw.githubusercontent.com/ssrando/ssrando/master/checks.yaml');
-        return yaml.load(data);
-    }
 }
 
 export default LogicLoader;

--- a/src/logic/LogicTweaks.js
+++ b/src/logic/LogicTweaks.js
@@ -24,7 +24,7 @@ class LogicTweaks {
             requirements.set('Can Access Earth Temple', 'Can Access Dungeon Entrance in Eldin Volcano');
             requirements.set('Can Access Lanayru Mining Facility', 'Can Access Dungeon Entrance in Lanayru Desert');
             requirements.set('Can Access Ancient Cistern', 'Can Access Dungeon Entrance in Lake Floria');
-            requirements.set('Can Access Sandship', 'Can Access Dungeon Entrance in Sand Sea');
+            requirements.set('Can Access Sandship', 'Can Access Dungeon Entrance in Lanayru Sand Sea');
             requirements.set('Can Access Fire Sanctuary', 'Can Access Dungeon Entrance in Volcano Summit');
             requirements.set('Can Access Sky Keep', 'Can Access Dungeon Entrance on Skyloft');
             requirements.set('Can Beat Dungeon Entrance in Lanayru Desert', 'Can Beat Lanayru Mining Facility');

--- a/src/permalink/Settings.js
+++ b/src/permalink/Settings.js
@@ -127,9 +127,9 @@ class Settings {
         this.allOptions = await yaml.load(text);
         // correctly load the choices for excluded locations
         const excludedLocsIndex = this.allOptions.findIndex((x) => (x.name === 'Excluded Locations'));
-        const newChecks = await LogicLoader.loadNewLogicChecks();
+        const checks = await LogicLoader.loadLogicFile('checks.yaml');
         this.allOptions[excludedLocsIndex].choices = [];
-        _.forEach(newChecks, (data, location) => {
+        _.forEach(checks, (data, location) => {
             this.allOptions[excludedLocsIndex].choices.push(location);
         });
     }


### PR DESCRIPTION
The new backwards compatibility patch for the main rando means these fixes are no longer needed.

Slightly cleans up nonprogress evaluation.