### PR TITLE
Fix open-lmf naming bug

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -517,14 +517,14 @@ export default class Options extends React.Component {
                                 <FormGroup>
                                     <Row>
                                         <Col xs={5}>
-                                            <FormLabel htmlFor="openLMF">Open LMF</FormLabel>
+                                            <FormLabel htmlFor="openLMF">Open Lanayru Mining Facility</FormLabel>
                                         </Col>
                                         <Col xs={5}>
                                             <FormControl
                                                 as="select"
                                                 id="openLMF"
                                                 onChange={this.changeLMF}
-                                                value={this.state.settings.getOption('Open LMF')}
+                                                value={this.state.settings.getOption('Open Lanayru Mining Facility')}
                                                 custom
                                             >
                                                 <option>Nodes</option>


### PR DESCRIPTION
Fixes the bug where the Lanayru Desert checks showed the incorrect logic when the `open-lmf` option was set to "Main Node" or "Open". This was due to the option name being changed from "Open LMF" to "Open Lanayru Mining Facility".