### PR TITLE
New shuffles & relic mode support

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -203,9 +203,9 @@ export default class Options extends React.Component {
         this.changeBinaryOption = this.changeBinaryOption.bind(this);
         this.changeStartingTablets = this.changeStartingTablets.bind(this);
         this.changeEntranceRando = this.changeEntranceRando.bind(this);
-        this.changeShopMode = this.changeShopMode.bind(this);
-        this.changeBatreaux = this.changeBatreaux.bind(this);
-        this.changeRupeesanityMode = this.changeRupeesanityMode.bind(this);
+        this.changeShopsanity = this.changeBinaryOption.bind(this, 'Shopsanity');
+        this.changeTadtonesanity = this.changeBinaryOption.bind(this, 'Tadtonesanity');
+        this.changeRupeesanity = this.changeBinaryOption.bind(this, 'Rupeesanity');
         this.changeGoddess = this.changeBannedLocation.bind(this, 'goddess');
         this.changeStartingSword = this.changeStartingSword.bind(this);
         this.changeRaceMode = this.changeBinaryOption.bind(this, 'Empty Unrequired Dungeons');
@@ -264,12 +264,6 @@ export default class Options extends React.Component {
         this.forceUpdate();
     }
 
-    changeBatreaux(e) {
-        const { value } = e.target;
-        this.state.settings.setOption('Max Batreaux Reward', parseInt(value, 10));
-        this.forceUpdate();
-    }
-
     changeThunderhead(e) {
         const { value } = e.target;
         this.state.settings.setOption('Open Thunderhead', value);
@@ -282,30 +276,9 @@ export default class Options extends React.Component {
         this.forceUpdate();
     }
 
-    changeShopMode(e) {
-        const { value } = e.target;
-        // TODO: FIX PLS
-        // this.setState((prevState) => {
-        //     if (prevState.options['shop-mode'] === 'Randomized' || value === 'Randomized') {
-        //         // if mode was previously randomized, or shops will now be randomized, toggle the ban on shops
-        //         this.changeBannedLocation('cheap');
-        //         this.changeBannedLocation('medium');
-        //         this.changeBannedLocation('expensive');
-        //     }
-        // });
-        this.state.settings.setOption('Shop Mode', value);
-        this.forceUpdate();
-    }
-
     changeTriforceShuffle(e) {
         const { value } = e.target;
         this.state.settings.setOption('Triforce Shuffle', value);
-        this.forceUpdate();
-    }
-
-    changeRupeesanityMode(e) {
-        const { value } = e.target;
-        this.state.settings.setOption('Rupeesanity', value);
         this.forceUpdate();
     }
 
@@ -369,59 +342,32 @@ export default class Options extends React.Component {
                     <FormGroup as="fieldset" style={style}>
                         <legend style={legendStyle}>Shuffles</legend>
                         <Row>
-                            <Col xs={2}>
-                                <FormLabel htmlFor="batreaux">Max Batreaux Reward</FormLabel>
+                            <Col xs={3}>
+                                <FormCheck
+                                    type="switch"
+                                    label="Shuffle Beedle's Shop"
+                                    id="shopsanity"
+                                    checked={this.state.settings.getOption('Shopsanity')}
+                                    onChange={this.changeShopsanity}
+                                />
                             </Col>
-                            <Col xs={2}>
-                                <FormControl
-                                    as="select"
-                                    id="batreaux"
-                                    onChange={this.changeBatreaux}
-                                    value={this.state.settings.getOption('Max Batreaux Reward')}
-                                    custom
-                                >
-                                    <option>0</option>
-                                    <option>5</option>
-                                    <option>10</option>
-                                    <option>30</option>
-                                    <option>40</option>
-                                    <option>50</option>
-                                    <option>70</option>
-                                    <option>80</option>
-                                </FormControl>
-                            </Col>
-                            <Col xs={1}>
-                                <FormLabel htmlFor="shopMode">Shop Mode</FormLabel>
-                            </Col>
-                            <Col xs={2}>
-                                <FormControl
-                                    as="select"
-                                    id="shopMode"
-                                    onChange={this.changeShopMode}
-                                    value={this.state.settings.getOption('Shop Mode')}
-                                    custom
-                                >
-                                    <option>Vanilla</option>
-                                    <option>Randomized - Cheap</option>
-                                    <option>Randomized - Medium</option>
-                                    <option>Randomized - Expensive</option>
-                                </FormControl>
-                            </Col>
-                            <Col xs={1}>
-                                <FormLabel htmlFor="rupeesanity">Rupeesanity</FormLabel>
-                            </Col>
-                            <Col xs={2}>
-                                <FormControl
-                                    as="select"
+                            <Col xs={3}>
+                                <FormCheck
+                                    type="switch"
+                                    label="Rupeesanity"
                                     id="rupeesanity"
-                                    onChange={this.changeRupeesanityMode}
-                                    value={this.state.settings.getOption('Rupeesanity')}
-                                    custom
-                                >
-                                    <option>Vanilla</option>
-                                    <option>No Quick Beetle</option>
-                                    <option>All</option>
-                                </FormControl>
+                                    checked={this.state.settings.getOption('Rupeesanity')}
+                                    onChange={this.changeRupeesanity}
+                                />
+                            </Col>
+                            <Col xs={3}>
+                                <FormCheck
+                                    type="switch"
+                                    label="Tadtonesanity"
+                                    id="tadtonesanity"
+                                    checked={this.state.settings.getOption('Tadtonesanity')}
+                                    onChange={this.changeTadtonesanity}
+                                />
                             </Col>
                         </Row>
                     </FormGroup>

--- a/src/data/shuffleChecks.json
+++ b/src/data/shuffleChecks.json
@@ -1,5 +1,19 @@
 {
-    "All": {
+    "shopsanity": {
+        "Beedle's Shop": [
+            "50 Rupee Item",
+            "First 100 Rupee Item",
+            "Second 100 Rupee Item",
+            "Third 100 Rupee Item",
+            "300 Rupee Item",
+            "600 Rupee Item",
+            "800 Rupee Item",
+            "1000 Rupee Item",
+            "1200 Rupee Item",
+            "1600 Rupee Item"
+        ]
+    },
+    "rupeesanity": {
         "Central Skyloft": [
             "Rupee Waterfall Cave Crawlspace"
         ],
@@ -54,15 +68,32 @@
             "Ancient Harbour - Left Rupee on Entrance Crown",
             "Pirate Stronghold - Rupee on East Sea Pillar",
             "Pirate Stronghold - Rupee on West Sea Pillar",
-            "Pirate Stronghold - Rupee on Bird Statue Pillar or Nose"
-        ]
-    },
-    "Quick Beetle": {
-        "Lanayru Sand Sea": [
+            "Pirate Stronghold - Rupee on Bird Statue Pillar or Nose",
             "Ancient Harbour - Right Rupee on Entrance Crown",
             "Ancient Harbour - Left Rupee on Entrance Crown",
             "Pirate Stronghold - Rupee on East Sea Pillar",
             "Pirate Stronghold - Rupee on West Sea Pillar"
+        ]
+    },
+    "tadtonesanity": {
+        "Flooded Faron Woods": [
+            "Yellow Tadtone under Lilypad",
+            "8 Light Blue Tadtones near Viewing Platform",
+            "4 Purple Tadtones under Viewing Platform",
+            "Red Moving Tadtone near Viewing Platform",
+            "Light Blue Tadtone under Great Tree Root",
+            "8 Yellow Tadtones near Kikwi Elder",
+            "4 Light Blue Moving Tadtones under Kikwi Elder",
+            "4 Red Moving Tadtones North West of Great Tree",
+            "Green Tadtone behind Upper Bombable Rock",
+            "2 Dark Blue Tadtones in Grass West of Great Tree",
+            "8 Green Tadtones in West Tunnel",
+            "2 Red Tadtones in Grass near Lower Bombable Rock",
+            "16 Dark Blue Tadtones in the South West",
+            "4 Purple Moving Tadtones near Floria Gate",
+            "Dark Blue Moving Tadtone inside Small Hollow Tree",
+            "4 Yellow Tadtones under Small Hollow Tree",
+            "8 Purple Tadtones in Clearing after Small Hollow Tree"
         ]
     }
 }

--- a/src/logic/Locations.js
+++ b/src/logic/Locations.js
@@ -13,22 +13,12 @@ class Locations {
                 area,
                 location,
             } = Locations.splitLocationName(name);
-            const shopMode = settings.getOption('Shop Mode');
-            let maxBeedle;
-            if (shopMode === 'Vanilla') {
-                maxBeedle = 0;
-            } else if (shopMode === 'Randomized - Cheap') {
-                maxBeedle = 300;
-            } else if (shopMode === 'Randomized - Medium') {
-                maxBeedle = 1000;
-            } else {
-                maxBeedle = 1600;
+            let maxRelics = settings.getOption('Trial Treasure Amount');
+            if (!settings.getOption('Treasuresanity in Silent Realms')) {
+                maxRelics = 0;
             }
-            if (area === 'Batreaux\'s House') {
-                nonprogress |= (parseInt(location.replace(/^\D+/g, ''), 10) > settings.getOption('Max Batreaux Reward'));
-            }
-            if (area === 'Beedle\'s Shop') {
-                nonprogress |= (parseInt(location.replace(/^\D+/g, ''), 10) > maxBeedle);
+            if (area.includes('Silent Realm')) {
+                nonprogress |= (parseInt(location.replace(/^\D+/g, ''), 10) > maxRelics);
             }
             const itemLocation = ItemLocation.emptyLocation();
             itemLocation.name = location;

--- a/src/logic/Logic.js
+++ b/src/logic/Logic.js
@@ -9,7 +9,7 @@ import ItemLocation from './ItemLocation';
 import crystalLocations from '../data/crystals.json';
 import potentialBannedLocations from '../data/potentialBannedLocations.json';
 import logicFileNames from '../data/logicModeFiles.json';
-import rupeesanityChecks from '../data/rupeesanityChecks.json';
+import shuffleChecks from '../data/shuffleChecks.json';
 
 class Logic {
     async initialize(settings, startingItems, source) {
@@ -182,7 +182,7 @@ class Logic {
         // do an initial requirements check to ensure nothing requirements and starting items are properly considered
         this.checkAllRequirements();
         this.updateAllCounters();
-        this.updateRupeesanityBannedLocations();
+        this.updateShuffleBannedLocations();
         this.updatePastRequirement();
         if (this.settings.getOption('Empty Unrequired Dungeons')) {
             this.updateRaceModeBannedLocations();
@@ -547,7 +547,6 @@ class Logic {
         this.updatePastRequirement();
         if (this.settings.getOption('Empty Unrequired Dungeons')) {
             this.updateRaceModeBannedLocations();
-            this.updateRupeesanityBannedLocations();
         }
         this.checkAllRequirements();
     }
@@ -602,16 +601,25 @@ class Logic {
         this.updateAllCounters();
     }
 
-    updateRupeesanityBannedLocations() {
-        if (this.settings.getOption('Rupeesanity') === 'Vanilla') {
-            _.forEach(rupeesanityChecks.All, (locations, area) => {
+    updateShuffleBannedLocations() {
+        if (!this.settings.getOption('Shopsanity')) {
+            _.forEach(shuffleChecks.shopsanity, (locations, area) => {
                 _.forEach(locations, (check) => {
                     const itemLocation = this.getLocation(area, check);
                     itemLocation.nonprogress = true;
                 });
             });
-        } else if (this.settings.getOption('Rupeesanity') === 'No Quick Beetle') {
-            _.forEach(rupeesanityChecks['Quick Beetle'], (locations, area) => {
+        }
+        if (!this.settings.getOption('Rupeesanity')) {
+            _.forEach(shuffleChecks.rupeesanity, (locations, area) => {
+                _.forEach(locations, (check) => {
+                    const itemLocation = this.getLocation(area, check);
+                    itemLocation.nonprogress = true;
+                });
+            });
+        }
+        if (!this.settings.getOption('Tadtonesanity')) {
+            _.forEach(shuffleChecks.tadtonesanity, (locations, area) => {
                 _.forEach(locations, (check) => {
                     const itemLocation = this.getLocation(area, check);
                     itemLocation.nonprogress = true;


### PR DESCRIPTION
Changes old multichoice shuffle modes to the new boolean shuffle modes. Also bans any trial dusk relic checks greater than the maximum count in the user's settings.