### PR TITLE
Reintroduce shuffle ban check with EUD

### DIFF
--- a/src/logic/Logic.js
+++ b/src/logic/Logic.js
@@ -185,6 +185,7 @@ class Logic {
         this.updatePastRequirement();
         if (this.settings.getOption('Empty Unrequired Dungeons')) {
             this.updateRaceModeBannedLocations();
+            this.updateShuffleBannedLocations();
         }
         this.hasItem = this.hasItem.bind(this);
         this.isRequirementMet = this.isRequirementMet.bind(this);


### PR DESCRIPTION
I erroneously removed the line that updated rupeesanity banned locations when a dungeon was clicked with EUD on.