### PR TITLE
Grab latest rando release as a source automatically, move source next to permalink

### DIFF
--- a/src/Options.js
+++ b/src/Options.js
@@ -338,7 +338,30 @@ export default class Options extends React.Component {
                             Settings String:
                             <input id="permalink" className="permalinkInput" placeholder="Permalink" value={this.state.settings.generatePermalink()} onChange={this.permalinkChanged} />
                         </label>
+                        <div title="main, beta-features, and asyncs will pull from the latest update to that branch">
+                            <Row>
+                                <Col>
+                                    <FormLabel htmlFor="fileSource">Randomizer Version</FormLabel>
+                                </Col>
+                                <Col>
+                                    <FormControl
+                                        as="select"
+                                        id="fileSource"
+                                        onChange={this.updateSource}
+                                        value={this.state.source}
+                                        custom
+                                    >
+                                        <option>v2.0.0</option>
+                                        <option>main</option>
+                                        <option>v1.4.1</option>
+                                        <option>beta-features</option>
+                                        <option>asyncs</option>
+                                    </FormControl>
+                                </Col>
+                            </Row>
+                        </div>
                     </div>
+
                     <FormGroup as="fieldset" style={style}>
                         <legend style={legendStyle}>Shuffles</legend>
                         <Row>
@@ -545,33 +568,12 @@ export default class Options extends React.Component {
                         </Row>
                     </FormGroup>
                     <Row>
-                        <Col xs={9}>
+                        <Col>
                             <Link to={{ pathname: '/tracker', search: `?options=${encodeURIComponent(this.state.settings.generatePermalink())}&source=${this.state.source}` }}>
                                 <Button variant="primary">
                                     Launch New Tracker
                                 </Button>
                             </Link>
-                        </Col>
-                        <Col xs={3}>
-                            <Row>
-                                <Col>
-                                    <FormLabel htmlFor="fileSource">Data Source</FormLabel>
-                                </Col>
-                                <Col>
-                                    <FormControl
-                                        as="select"
-                                        id="fileSource"
-                                        onChange={this.updateSource}
-                                        value={this.state.source}
-                                        custom
-                                    >
-                                        <option>main</option>
-                                        <option>beta-features</option>
-                                        <option>v1.4.1</option>
-                                        <option>asyncs</option>
-                                    </FormControl>
-                                </Col>
-                            </Row>
                         </Col>
                     </Row>
                 </Form>

--- a/src/Options.js
+++ b/src/Options.js
@@ -17,6 +17,12 @@ export default class Options extends React.Component {
             ready: false,
             source: 'main',
         };
+        const versionData = this.getVersionData();
+        versionData.then((value) => {
+            // pull the name of the latest version
+            this.latestVersion = value[0].tag_name;
+            this.state.source = this.latestVersion;
+        });
         // these regions are irrelevant now with the removal of banned types, will keep in until full new logic unfreeze
         this.regions = [
             {
@@ -224,6 +230,13 @@ export default class Options extends React.Component {
         });
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    async getVersionData() {
+        const releaseData = await fetch('https://api.github.com/repos/ssrando/ssrando/releases');
+        const release = await releaseData.json();
+        return release;
+    }
+
     changeBinaryOption(option) {
         // for some reason this correct method of setting state does not work correctly in our case
         // as such we must revert to the incorrect method which may result in unexpected/undefined behavior
@@ -351,7 +364,7 @@ export default class Options extends React.Component {
                                         value={this.state.source}
                                         custom
                                     >
-                                        <option>v2.0.1</option>
+                                        <option>{this.latestVersion}</option>
                                         <option>main</option>
                                         <option>beta-features</option>
                                         <option>asyncs</option>

--- a/src/Options.js
+++ b/src/Options.js
@@ -351,9 +351,8 @@ export default class Options extends React.Component {
                                         value={this.state.source}
                                         custom
                                     >
-                                        <option>v2.0.0</option>
+                                        <option>v2.0.1</option>
                                         <option>main</option>
-                                        <option>v1.4.1</option>
                                         <option>beta-features</option>
                                         <option>asyncs</option>
                                     </FormControl>


### PR DESCRIPTION
This makes it so the tracker automatically pulls the latest rando release tag for the tracker. I also moved the source field up to the top of the launcher, next to the settings string input (and renamed the label to Randomizer Version) so new users are more likely to see it and understand how to configure the tracker correctly.

Support for v1.4.1 was dropped as it currently does not work with the tracker amidst new name scheme changes.