### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@
 
 name: Node.js CI
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -12,22 +12,22 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [18.x, 20.x, 21.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm install
     - run: npm run build
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
-        name: SSR-Tracker-Build
+        name: SSR-Tracker-Build-${{ matrix.node-version }}
         
         # A file, directory or wildcard pattern that describes what to upload
         path: build


### PR DESCRIPTION
* Run the workflow on pull requests too (this means testing the build for PRs too)
* Update Node versions, as the previously listed versions are EOL
* Updates some actions that themselves are based on now EOL Node versions
* Disambiguates the artifact name as required by `actions/upload-artifact@v4`