### PR TITLE
Load the correct options.yaml in Options

### DIFF
--- a/src/utils/Cancel.ts
+++ b/src/utils/Cancel.ts
@@ -1,0 +1,40 @@
+/**
+ * A CancelToken should be passed to cancelable functions. Those functions should then check the state of the
+ * token and return early, or use checkCanceled to throw a CanceledError if the token has been canceled. Callers
+ * of cancelable functions should catch CanceledError.
+ */
+export interface CancelToken {
+    readonly canceled: boolean;
+    checkCanceled: () => void;
+}
+
+/**
+ * Indicates that the function was canceled by a call to the cancellation token's cancel function.
+ */
+export class CanceledError extends Error {
+    constructor() {
+        super('canceled');
+        this.name = 'CanceledError';
+    }
+}
+
+/**
+ * Returns a cancel token and a cancellation function. The token can be passed to functions and checked
+ * to see whether it has been canceled. The function can be called to cancel the token.
+ */
+export function withCancel(): [CancelToken, () => void] {
+    let isCanceled = false;
+    return [
+        {
+            get canceled() {
+                return isCanceled;
+            },
+            checkCanceled() {
+                if (isCanceled) {
+                    throw new CanceledError();
+                }
+            },
+        },
+        () => (isCanceled = true),
+    ];
+}


### PR DESCRIPTION
Opening the tracker usually shows a v2.1.1 release, but internally options.yaml is still loaded from main. This can lead to unexpected settings incompatibilities.

This fixes the issue by ensuring that the correct options are being loaded at all times, even if the user doesn't interact with the source dropdown.